### PR TITLE
Add missing post-upgrade cleanup phase in tmt_upgrade mode

### DIFF
--- a/mcase/lib.sh
+++ b/mcase/lib.sh
@@ -976,6 +976,7 @@ __distribution_mcase__w_tmt_upgrade() {
     elif test "$IN_PLACE_UPGRADE" == "new"; then
         echo test
         echo diag
+        echo cleanup
     else
         __distribution_mcase__error "invalid tmt_upgrade call; stage not applicable"
     fi


### PR DESCRIPTION
Users reported that their mcase tests do not run the cleanup phase in post-upgrade phase.
This commit should fix that.
jira ref OAMG-7873